### PR TITLE
Display workflow input & output names

### DIFF
--- a/app/src/workflow.js
+++ b/app/src/workflow.js
@@ -20,7 +20,6 @@ workflow = function (selection) {
         strokeColor = "#333",
         tooltip = selection.append("div").style("opacity", 0).style("position", "absolute");
 
-
     // Update the SVG path for a connection
     function connectionPath(d) {
         var dist,


### PR DESCRIPTION
When a user hovers over an input or output connection in a workflow, the name of that dataset now shows up as a tooltip.

We could probably do a better job with the styling of these new tooltips, but functionality-wise I think we're in good shape.  This branch addresses https://github.com/Kitware/tangelohub/issues/59.

<!---
@huboard:{"order":79.0,"milestone_order":79,"custom_state":""}
-->
