### PR TITLE
Maintain compatibility with new types plugin in Girder Worker

### DIFF
--- a/devops/ansible/roles/girder_worker/tasks/pip.yml
+++ b/devops/ansible/roles/girder_worker/tasks/pip.yml
@@ -16,8 +16,15 @@
     chdir: "{{ girder_worker_path }}"
     virtualenv: "{{ girder_worker_virtualenv | default(omit) }}"
 
+- name: Check if requirements.txt for each plugin exists
+  stat:
+    path: "{{ girder_worker_path }}/girder_worker/plugins/{{ item }}/requirements.txt"
+  with_items: "{{ girder_worker_plugins }}"
+  register: requirements_files
+
 - name: Install Girder Worker plugin requirements
   pip:
-    requirements: "{{ girder_worker_path }}/girder_worker/plugins/{{ item }}/requirements.txt"
+    requirements: "{{ item.stat.path }}"
     virtualenv: "{{ girder_worker_virtualenv | default(omit) }}"
-  with_items: "{{ girder_worker_plugins }}"
+  with_items: "{{ requirements_files.results }}"
+  when: item.stat.exists

--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -17,7 +17,7 @@
     girder_virtualenv: "{{ ansible_user_dir }}/.virtualenvs/girder"
     girder_version: "v1.7.0"
     girder_worker_path: "/opt/girder_worker"
-    girder_worker_plugins: ["r"]
+    girder_worker_plugins: ["types", "r"]
     girder_worker_version: "master"
     girder_worker_virtualenv: "{{ ansible_user_dir }}/.virtualenvs/girder"
     flow_path: "/opt/flow"


### PR DESCRIPTION
The ansible install for GW changed to only install the
requirements.txt files for each plugin if they actually existed. This
is due to the fact that the types plugin has no requirements.txt file,
which exposed this bug.

ref https://github.com/girder/girder_worker/pull/88

@jeffbaumes Mind testing this? If the above PR isn't merged by the time you test then `girder_worker_version` in devops/ansible/site.yml will need to be changed to `optional-typesystem`.